### PR TITLE
Namespace reorganisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,25 @@ $ dotnet restore
 
 ```c#
 
-public static void Main(string[] args)
+public class Program
 {
-    var app = new VulpixServer();
-    var foo = new MyController();
-    app.AddRoute("GET","/", (Req req, Res res)=>{
-      await res.Response.WriteAsync("Hello World!");
-    });
-    app.Listen();
+    public static void Main(string[] args)
+    {
+        var app = new VulpixServer();
+        var foo = new MyController();
+
+        app.AddRoute("GET", "/", foo.Index);
+        app.Use(new BodyParser().Exec);
+        app.Listen(5000);
+    }
+
+    public class MyController
+    {
+        public async void Index(Req req, Res res)
+        {
+            await res.Send("Hello world!");
+        }
+    }
 }
 ```
   Start the server:

--- a/Vulpix/src/Vulpix.Test/Program.cs
+++ b/Vulpix/src/Vulpix.Test/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using Vulpix.Middlewares;
+using Vulpix.Objects;
 
 namespace Vulpix.Test
 {

--- a/Vulpix/src/Vulpix.Test/Program.cs
+++ b/Vulpix/src/Vulpix.Test/Program.cs
@@ -16,15 +16,12 @@ namespace Vulpix.Test
             app.Use(new BodyParser().Exec);
             app.Listen(5000);
         }
+
         public class MyController
         {
             public async void Index(Req req, Res res)
             {
-                Console.WriteLine("GET: /");
-
-                byte[] response = Encoding.ASCII.GetBytes("Hello world!");
-
-                await res.Response.Body.WriteAsync(response, 0, response.Length);
+                await res.Send("Hello world!");
             }
         }
     }

--- a/Vulpix/src/Vulpix.Test/Program.cs
+++ b/Vulpix/src/Vulpix.Test/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using Vulpix.Middlewares;
 
 namespace Vulpix.Test
 {

--- a/Vulpix/src/Vulpix/Middlewares/Router.cs
+++ b/Vulpix/src/Vulpix/Middlewares/Router.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using Vulpix.Objects;
 
 namespace Vulpix.Middlewares
 {

--- a/Vulpix/src/Vulpix/Middlewares/Router.cs
+++ b/Vulpix/src/Vulpix/Middlewares/Router.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 
-namespace Vulpix
+namespace Vulpix.Middlewares
 {
     public class Router
     {

--- a/Vulpix/src/Vulpix/Middlewares/bodyparser.cs
+++ b/Vulpix/src/Vulpix/Middlewares/bodyparser.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using Newtonsoft.Json;
-
+using Vulpix.Objects;
 
 namespace Vulpix.Middlewares
 {

--- a/Vulpix/src/Vulpix/Middlewares/bodyparser.cs
+++ b/Vulpix/src/Vulpix/Middlewares/bodyparser.cs
@@ -3,7 +3,7 @@ using System.IO;
 using Newtonsoft.Json;
 
 
-namespace Vulpix
+namespace Vulpix.Middlewares
 {
     public class BodyParser
     {

--- a/Vulpix/src/Vulpix/Object/Res.cs
+++ b/Vulpix/src/Vulpix/Object/Res.cs
@@ -1,38 +1,46 @@
-
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 
 namespace Vulpix
 {
-     public class Res{
-
+    public class Res
+    {
         public HttpResponse Response;
 
-
-        public Res(HttpContext context){
-    	    this.Response = context.Response;
+        public Res(HttpContext context)
+        {
+            this.Response = context.Response;
         }
 
-        public async Task Send(object obj){
-                 Response.StatusCode = 200;
-                 Response.ContentType = "application/json";
-                 await Response.WriteAsync(JsonConvert.SerializeObject(obj));
+        public async Task Send(object obj)
+        {
+            await this.Send(obj, 200);
+            //Response.StatusCode = 200;
+            //Response.ContentType = "application/json";
+            //await Response.WriteAsync(JsonConvert.SerializeObject(obj));
         }
-        public async Task Send(object obj, int code){
-                 Response.StatusCode = code;
-                 Response.ContentType = "application/json";
-                 await Response.WriteAsync(JsonConvert.SerializeObject(obj));
+
+        public async Task Send(object obj, int code)
+        {
+            Response.StatusCode = code;
+            Response.ContentType = "application/json";
+            await Response.WriteAsync(JsonConvert.SerializeObject(obj));
         }
-        public async Task Send(string text){          
-                 Response.StatusCode = 200;
-                 Response.ContentType = "text/HTML";
-                 await Response.WriteAsync(text);
+
+        public async Task Send(string text)
+        {
+            await this.Send(text, 200);
+            //Response.StatusCode = 200;
+            //Response.ContentType = "text/HTML";
+            //await Response.WriteAsync(text);
         }
-        public async Task Send(string text, int code){        
-                 Response.StatusCode = code;
-                 Response.ContentType = "text/HTML";
-                 await Response.WriteAsync(text);
+
+        public async Task Send(string text, int code)
+        {
+            Response.StatusCode = code;
+            Response.ContentType = "text/HTML";
+            await Response.WriteAsync(text);
         }
     }
 }

--- a/Vulpix/src/Vulpix/Objects/Middleware.cs
+++ b/Vulpix/src/Vulpix/Objects/Middleware.cs
@@ -1,7 +1,7 @@
 using System;
 
 
-namespace Vulpix
+namespace Vulpix.Objects
 {
 
      public class Middleware{

--- a/Vulpix/src/Vulpix/Objects/Req.cs
+++ b/Vulpix/src/Vulpix/Objects/Req.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 
 
-namespace Vulpix
+namespace Vulpix.Objects
 {
 
      public class Req{

--- a/Vulpix/src/Vulpix/Objects/Res.cs
+++ b/Vulpix/src/Vulpix/Objects/Res.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 
-namespace Vulpix
+namespace Vulpix.Objects
 {
     public class Res
     {

--- a/Vulpix/src/Vulpix/Objects/ResultValidate.cs
+++ b/Vulpix/src/Vulpix/Objects/ResultValidate.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 
 
-namespace Vulpix
+namespace Vulpix.Objects
 {
     public class ResultValidate{
      public bool IsValid;

--- a/Vulpix/src/Vulpix/Objects/Route.cs
+++ b/Vulpix/src/Vulpix/Objects/Route.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 
 
-namespace Vulpix
+namespace Vulpix.Objects
 {
 
  public class Route{

--- a/Vulpix/src/Vulpix/Objects/Singleton.cs
+++ b/Vulpix/src/Vulpix/Objects/Singleton.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
 
-namespace Vulpix
+namespace Vulpix.Objects
 {
 public class Singleton
 {

--- a/Vulpix/src/Vulpix/Objects/VulpixConfigurationSingleton.cs
+++ b/Vulpix/src/Vulpix/Objects/VulpixConfigurationSingleton.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 
 
-namespace Vulpix
+namespace Vulpix.Objects
 {
 public class VulpixConfiguration
 {

--- a/Vulpix/src/Vulpix/Startup.cs
+++ b/Vulpix/src/Vulpix/Startup.cs
@@ -1,11 +1,12 @@
 using Vulpix;
- public class Startup : VulpixCore
-  {
 
-    public Startup(){
-      var config = VulpixConfiguration.GetConfiguration();
-      base.SetRoute(config.GetRoute());
-      base.SetMiddleware(config.GetMiddleware());
-      base.SetPublicFolder(config.GetPublicFolder());
+public class Startup : VulpixCore
+{
+    public Startup()
+    {
+        var config = VulpixConfiguration.GetConfiguration();
+        base.SetRoute(config.GetRoute());
+        base.SetMiddleware(config.GetMiddleware());
+        base.SetPublicFolder(config.GetPublicFolder());
     }
-  }
+}

--- a/Vulpix/src/Vulpix/Startup.cs
+++ b/Vulpix/src/Vulpix/Startup.cs
@@ -1,4 +1,5 @@
 using Vulpix;
+using Vulpix.Objects;
 
 public class Startup : VulpixCore
 {

--- a/Vulpix/src/Vulpix/VulpixCore.cs
+++ b/Vulpix/src/Vulpix/VulpixCore.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.FileProviders;
+using Vulpix.Objects;
 
 namespace Vulpix
 {

--- a/Vulpix/src/Vulpix/VulpixServer.cs
+++ b/Vulpix/src/Vulpix/VulpixServer.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Hosting;
 
 using Microsoft.Extensions.Configuration;
 
+using Vulpix.Middlewares;
+
 
 namespace Vulpix
 {

--- a/Vulpix/src/Vulpix/VulpixServer.cs
+++ b/Vulpix/src/Vulpix/VulpixServer.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 
 using Vulpix.Middlewares;
-
+using Vulpix.Objects;
 
 namespace Vulpix
 {

--- a/Vulpix/src/Vulpix/project.json
+++ b/Vulpix/src/Vulpix/project.json
@@ -2,7 +2,7 @@
   "title": "Vulpix",
   "copyright": "Copyright 2016",
   "language": "en",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "runtimes": {
     "win7-x64": { },
     "win10-x64":{}


### PR DESCRIPTION
During the implementation of the middleware abstraction (for issue #3), I've ran into a little problem of namespace, so I've reorganised the namespaces like this:

- **Root folder** : namespace : _Vulpix_
- **Middlewares** folder : namespace : _Vulpix.Middlewares_
- **Objects** folder : namespace : _Vulpix.Objects_

I've also updated the `Res.cs` file to simplify the code.